### PR TITLE
Fix Job Title Regex

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,12 +1,14 @@
 {
   "browserPath": "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
   "keyword": [
+    "\"Software Engineer\"",
     "\"Full Stack Engineer\"",
     "\"fullstack developer\"",
     "\"full stack developer\"",
     "\"javascript developer\"",
     "\"nodejs developer\"",
-    "\"java developer\""
+    "\"Java Developer\"",
+    "\"Java Engineer\""
   ],
   "workPlaceTypes": {
     "onsite": "#workplaceType-1",
@@ -21,7 +23,8 @@
   "numberOfPagination": 14,
   "numberOfOffersPerPage": 25,
   "avoidJobTitles": [
-    "Test",
+    "TEST",
+    "EMBEDDED",
     "PYTHON",
     "PRINCIPAL",
     "STAFF",
@@ -29,6 +32,7 @@
     "ANGULAR",
     ".NET",
     "C#",
+    "C++",
     "SHAREPOINT",
     "SHARE POINT",
     "LEAD",

--- a/index.js
+++ b/index.js
@@ -231,7 +231,7 @@ async function FillAndApply() {
 
         // Check if the job title is in the list of titles to avoid
         const jobTitleRegex = new RegExp(
-          `\\b(${avoidJobTitles.join("|")})\\b`,
+          `\\b(${avoidJobTitles.map((title) => title.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')).join("|")})(?=\\b|[^a-zA-Z0-9])`,
           "i"
         );
         if (jobTitleRegex.test(jobTitle)) {
@@ -324,7 +324,7 @@ async function FillAndApply() {
                   .click();
               });
             } else counter = -2;
-          } while (counter >= 0 && counter < 5);
+          } while (counter >= 0 && counter < 20);
 
           let skipped = false;
           if (counter >= 5) {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-    "version": "1.0.2",
+    "version": "1.0.3",
     "main": "index.js",
     "scripts": {
         "test": "echo \"Error: no test specified\" && exit 1",


### PR DESCRIPTION
## Issue description
This PR handles the job title regex for titles like `C++ developer` where the `+` symbol is a special character which refers to one or more of the previous characters. 

So essentially we check and escape special chars.

The second part of this PR is a minor change that increases the counter so the user has enough time for manual input.

## Tasks
- [x] Refactor Regex
- [x] Increment counter