### PR TITLE
Add Company Name Filter

### DIFF
--- a/config.json
+++ b/config.json
@@ -46,5 +46,6 @@
     "NET",
     "LOCAL",
     "CITIZEN"
-  ]
+  ],
+  "avoidCompanyNames": ["Test Company", "Defense Systems"]
 }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-    "version": "1.0.4",
+    "version": "1.0.5",
     "main": "index.js",
     "scripts": {
         "test": "echo \"Error: no test specified\" && exit 1",


### PR DESCRIPTION
## Issue Description

This PR handles filtering jobs by company name. For example, there are dummy companies like "Test Company" or companies that handle Government projects that require high-level clearance. 

A new array `avoidCompanyNames` is introduced in the `config.json` file to skip jobs from these companies if need be, else the user can leave it empty.

<img width="357" alt="image" src="https://github.com/user-attachments/assets/df051eda-fa03-4a16-b049-38f93b3eb7c4">


## Tasks

- [x] Add unwanted companies to the `avoidCompanyNames` array in `config.json`.
- [x] Add logic for skipping jobs from companies in the `avoidCompanyNames` array.
- [x] Refactor the `logs` function
- [x] Remove redundant comments and logs
